### PR TITLE
Initial reasonable version of a caching strategy for Arsenal

### DIFF
--- a/arsenal/strategy/SimpleProportionStrategy.py
+++ b/arsenal/strategy/SimpleProportionStrategy.py
@@ -1,0 +1,205 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo.config import cfg
+
+from arsenal.openstack.common import log
+import arsenal.strategy.base as base
+
+LOG = log.getLogger(__name__)
+
+CONF = cfg.CONF
+
+def build_attribute_set(items, attr_name):
+    """Build a set off of a particular attribute of a list of 
+    objects. Adds 'None' to the set if one or more of the
+    objects in items is missing the attribute specified by
+    attr_name."""
+    attribute_set = set()
+    for item in items:
+        attribute_set.add(getattr(item, attr_name, None))
+    return attribute_set
+
+def build_attribute_dict(items, attr_name):
+    """ Build a dict from a list of items and one of their attributes to make
+    querying the collection easier."""
+    attr_dict = {}
+    for item in items:
+        attr_dict[getattr(item, attr_name)] = item
+    return attr_dict
+
+class SimpleProportionStrategy(base.CachingStrategy):
+    def __init__(self):
+        self.percentage_to_cache = 40
+        self.current_state = {}
+
+    def update_current_state(self, nodes, images, flavors):
+        # For now, flavors should remain static.
+        # In the future we'll handle changing flavor profiles if needed,
+        # but it seems unlikely that flavors will change often enough.
+        self.flavor_diff = self.find_flavor_differences(flavors)
+        self.log_flavor_differences(self.flavor_diff)
+        self.current_flavors = flavors
+
+        # Image differences are important because changed or retired 
+        # images should be ejected from the cache.
+        self.image_diff = self.find_image_differences(images)
+        self.log_image_differences(self.image_diff)
+        self.current_images = images
+
+        # We don't compare old node state versus new, because that would be
+        # a relatively large and complicated task. Instead, we only rely on
+        # the current state of nodes to inform ourselves whether we're meeting
+        # our stated goals or not. 
+        self.current_nodes = nodes
+        
+    def directives(self):
+        """Return a list actions that should be taken by Arsenal in order to 
+        fulfill the strategy implemented by this object. Bases 
+        decision-making on data made available to it by Arsenal through 
+        update_current_state."""
+        
+        # Segregate nodes by flavor. 
+        nodes_by_flavor = {}
+        for flavor in self.current_flavors:
+            nodes_by_flavor[flavor.name] = []
+            for node in self.current_nodes:
+                if flavor.is_flavor_node(node):
+                    nodes_by_flavor[flavor.name].append(node)
+
+        # For each flavor, check for cached nodes that have old or 
+        # retired images. Eject them, and mark them as uncached internally.
+        for flavor_name, flavor_nodes in nodes_by_flavor.iteritems():
+            for node in flavor_nodes:
+                if (node.cached and 
+                    node.cached_image_uuid not in self.current_image_uuids):
+                        directives.append(EjectNode(node.node_uuid))
+                        # This marks the node internally so it's not 
+                        # considered currently cached anymore. We may issue
+                        # a CacheNode action below for the same node, 
+                        # but not necessarily.
+                        node.cached = False
+
+        # Once bad cached nodes have been ejected, determine the proportion
+        # of truly 'good' cached nodes. If we're not meeting or exceeding 
+        # our proportion goal, schedule (node, image) pairs to cache randomly 
+        # until we would meet our proportion goal.
+        for flavor_name, flavor_nodes in nodes_by_flavor.iteritems():
+            cached_percentage = determine_percentage_cached(flavor_nodes)
+            if cached_percentage < self.percentage_to_cache:
+                # TODO
+                # 
+
+        pass
+
+    def determine_minimum_nodes_needed_to_cache(self, nodes):
+        #TODO
+        pass
+
+    def determine_percentage_cached(self, nodes):
+        """Calculates the percentage of cached nodes in a particular set
+        of nodes."""
+        cached_nodes = 0
+        total_nodes = len(nodes)
+        for node in nodes:
+            if node.cached:
+                cached_nodes += 1
+        return (cached_nodes / total_nodes) * 100
+
+    def find_image_differences(self, new_image_list):
+        """Find differences between current image state and
+        previous. Did anything change? Which images specifically changed
+        their UUIDs? Are some images no longer present at all?
+        
+        Returns a dictionary of three attributes: 'new', 'changed', and 
+        'retired'. Each attribute is a set of image names.
+        'new' - Totally new image names.
+        'changed' - Images with the same name, but their UUID has changed.
+        'retired' - Image name which was previously present, but has since
+            disappeared.
+        """
+        old_image_names = build_attribute_set(self.current_images, 'name')
+        new_image_names = build_attribute_set(new_image_list, 'name')
+
+        new_images = new_image_names.difference(old_image_names)
+        retired_images = old_image_names.difference(new_image_names)
+
+        # Find 'changed' images
+        # This is a bit trickier since we need to check for changing UUIDs.
+        same_names = old_image_names.intersection(new_image_names)
+        old_image_dict = build_attribute_dict(self.current_images, 'name')
+        new_image_dict = build_attribute_dict(new_image_list, 'name')
+        changed_images = set()
+        for name in same_names:
+            new_image_obj = new_image_dict[name]
+            old_image_obj = old_image_dict[name]
+            # If the UUID of the image has changed, then we know the
+            # underlying image has changed somehow.
+            if new_image_obj.uuid != old_image_obj.uuid:
+                changed_images.add(name)
+
+        return { 'new': new_images, 
+                 'changed': changed_images,
+                 'retired': retired_images }
+
+    def log_image_differences(self, image_differences):
+        for image_name in image_differences['new']:
+            LOG.info("SimpleProportionStrategy: A new image has been "
+                      "detected. Image name: '%(name)s'", 
+                      { 'name': image_name })
+        for image_name in image_differences['changed']:
+            LOG.info("SimpleProportionStrategy: A changed image has been "
+                      "detected. Image name: '%(name)s'", 
+                      { 'name': image_name })
+        for image_name in image_differences['retired']:
+            LOG.info("SimpleProportionStrategy: A new image has been "
+                      "detected. Image name: '%(name)s'", 
+                      { 'name': image_name })
+
+    def find_flavor_differences(self, new_flavors):
+        """Do a diff on flavors last seen and new set of flavors.
+        return differences.
+
+        Assumes that nodes with a particular flavor name are homogeneous, and
+        will not change node specifications without an accompaying name change.
+
+        Returns a dictionary with two attributes: 'new', and 'retired'.
+        'new' - New flavor names.
+        'retired' - Flavor names no longer present.
+        All valid keys will map to sets of image names
+        as strings."""
+        previous_flavor_names = build_attribute_set(self.current_flavors, 
+                                                    'name')
+        new_flavor_names = build_attribute_set(new_flavors, 'name')
+
+        totally_new_flavors = new_flavor_names.difference(
+                                previous_flavor_names)
+        retired_flavors = previous_flavor_names.difference(new_flavor_names)
+                return {'new': totally_new_flavors, 'retired': retired_flavors}
+
+    def log_flavor_differences(self, flavor_differences):
+        for flavor_name in flavor_differences['new']:
+            LOG.info("SimpleProportionStrategy: A new flavor has been "
+                      "detected. Flavor name: '%(name)s'", 
+                      { 'name': flavor_name })
+
+        for flavor_name in flavor_differences['retired']:
+            LOG.info("SimpleProportionStrategy: A flavor has been retired. "
+                      "Flavor name: '%s(name)'",
+                      {'name': flavor_name})
+
+

--- a/arsenal/strategy/base.py
+++ b/arsenal/strategy/base.py
@@ -1,0 +1,104 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+
+AVAILABLE_ACTIONS = [
+    "CacheNode",
+    "EjectNode"
+]
+
+
+class StrategyInput(object):
+    """Base class for information destined for CachingStrategy objects."""
+    def __init__(self):
+        pass
+
+
+class NodeInput(StrategyInput):
+    def __init__(self, node_uuid, is_unprovisioned, is_cached, image_uuid):
+        super(NodeInput, self).__init__()
+        self.node_uuid = node_uuid
+        self.provisioned = is_unprovisioned
+        self.cached = is_cached   
+        self.cached_image_uuid = image_uuid
+
+
+class FlavorInput(StrategyInput):
+    def __init__(self, name, indentity_func):
+        super(FlavorInput, self).__init__()
+        self.name = name
+        self.is_flavor_node = identity_func
+
+
+class ImageInput(StrategyInput):
+    def __init__(self, name, uuid):
+        super(ImageInput, self).__init__()
+        self.name = name
+        self.uuid = uuid
+
+
+class StrategyAction(object):
+    """Base class for actions a CachingStratgy object may take."""
+    def __init__(self, format_string="{0}", format_attrs=['name']):
+        self.name = self.__class__.__name__
+
+    def __str__(self):
+        format_list = []
+        for attr in self.format_attrs:
+            format_list.append(getattr(self, attr))
+        return self.format_string.format(*format_list)
+
+
+class CacheNode(StrategyAction):
+    """Contains all the information necessary to cache a specific
+    image on a specific node."""
+    def __init__(self, node_uuid, image_uuid):
+        super(CacheNode, self).__init__(
+                    format_string="{0}: Cache image '{1}' on node '{0}'.",
+                    format_attrs=['name', 'image_uuid', 'node_uuid'] 
+                )
+        self.node_uuid = node_uuid
+        self.image_uuid = image_uuid
+
+
+class EjectNode(StrategyAction):
+    def __init__(self, node_uuid):
+        super(EjectNode, self).__init__(
+                    formart_string="{0}: Eject node '{1}' from cache.",
+                    format_attrs=['name', 'node_uuid']
+                )
+
+
+class CachingStrategy(abc.ABCMeta):
+    """Base object for objects that will implement a caching strategy for 
+    Arsenal."""
+
+    @abstractmethod
+    def update_current_state(self, nodes, images, flavors):
+        """ update_current_state should be called periodically to allow the
+        strategy to see what the current state of nodes, images, and flavors
+        are in the system.  
+        """
+        pass
+
+    @abstractmethod
+    def directives(self):
+        """ directives will return a list of simple actions Arsenal should take 
+        to fulfill this object's strategy, based on its view of the current
+        system state. """
+        pass

--- a/arsenal/strategy/base.py
+++ b/arsenal/strategy/base.py
@@ -79,9 +79,10 @@ class CacheNode(StrategyAction):
 class EjectNode(StrategyAction):
     def __init__(self, node_uuid):
         super(EjectNode, self).__init__(
-                    formart_string="{0}: Eject node '{1}' from cache.",
+                    format_string="{0}: Eject node '{1}' from cache.",
                     format_attrs=['name', 'node_uuid']
                 )
+        self.node_uuid = node_uuid
 
 
 class CachingStrategy(object):

--- a/arsenal/strategy/base.py
+++ b/arsenal/strategy/base.py
@@ -17,6 +17,8 @@
 
 import abc
 
+import six
+
 
 class StrategyInput(object):
     """Base class for information destined for CachingStrategy objects."""
@@ -29,12 +31,12 @@ class NodeInput(StrategyInput):
         super(NodeInput, self).__init__()
         self.node_uuid = node_uuid
         self.provisioned = is_provisioned
-        self.cached = is_cached   
+        self.cached = is_cached
         self.cached_image_uuid = image_uuid
 
     def can_cache(self):
         # If the node is not provisioned and not already caching an image,
-        # then it is available for caching. 
+        # then it is available for caching.
         return not self.provisioned and not self.cached
 
 
@@ -66,12 +68,13 @@ class StrategyAction(object):
 
 class CacheNode(StrategyAction):
     """Contains all the information necessary to cache a specific
-    image on a specific node."""
+    image on a specific node.
+    """
+
     def __init__(self, node_uuid, image_uuid):
         super(CacheNode, self).__init__(
-                    format_string="{0}: Cache image '{1}' on node '{0}'.",
-                    format_attrs=['name', 'image_uuid', 'node_uuid'] 
-                )
+            format_string="{0}: Cache image '{1}' on node '{0}'.",
+            format_attrs=['name', 'image_uuid', 'node_uuid'])
         self.node_uuid = node_uuid
         self.image_uuid = image_uuid
 
@@ -79,29 +82,29 @@ class CacheNode(StrategyAction):
 class EjectNode(StrategyAction):
     def __init__(self, node_uuid):
         super(EjectNode, self).__init__(
-                    format_string="{0}: Eject node '{1}' from cache.",
-                    format_attrs=['name', 'node_uuid']
-                )
+            format_string="{0}: Eject node '{1}' from cache.",
+            format_attrs=['name', 'node_uuid'])
         self.node_uuid = node_uuid
 
 
+@six.add_metaclass(abc.ABCMeta)
 class CachingStrategy(object):
-    """Base object for objects that will implement a caching strategy for 
-    Arsenal."""
-
-    __metaclass__ = abc.ABCMeta
+    """Base object for objects that will implement a caching strategy for
+    Arsenal.
+    """
 
     @abc.abstractmethod
     def update_current_state(self, nodes, images, flavors):
-        """ update_current_state should be called periodically to allow the
+        """update_current_state should be called periodically to allow the
         strategy to see what the current state of nodes, images, and flavors
-        are in the system.  
+        are in the system.
         """
         pass
 
     @abc.abstractmethod
     def directives(self):
-        """ directives will return a list of simple actions Arsenal should take 
+        """directives will return a list of simple actions Arsenal should take
         to fulfill this object's strategy, based on its view of the current
-        system state. """
+        system state.
+        """
         pass

--- a/arsenal/tests/strategy/test_simple_proportional_strategy.py
+++ b/arsenal/tests/strategy/test_simple_proportional_strategy.py
@@ -26,8 +26,6 @@ from arsenal.strategy import base as sb
 from arsenal.strategy import simple_proportional_strategy as sps
 from arsenal.tests import base as test_base
 
-random.seed()
-
 
 def name_starts_with(node, letter):
     return node.node_uuid[0] == letter

--- a/arsenal/tests/strategy/test_simple_proportional_strategy.py
+++ b/arsenal/tests/strategy/test_simple_proportional_strategy.py
@@ -137,7 +137,12 @@ class TestSimpleProportionalStrategy(test_base.TestCase):
                         cache_directive_count)))
 
     def test_node_ejection_behavior(self):
+        """Perform the ejection test for all test environments."""
+        for env_name, env in self.environments.iteritems():
+            print "Testing ejection behavior for '%s'." % env_name
+            self._ejection_test(env)
+
+    def _ejection_test(self, env):
         """Are we ejecting nodes whose images are no longer in the current 
         image list?"""
-        # self.assertTrue(False, "TODO")
         pass

--- a/arsenal/tests/strategy/test_simple_proportional_strategy.py
+++ b/arsenal/tests/strategy/test_simple_proportional_strategy.py
@@ -22,29 +22,31 @@ behavior appears to be correct.
 
 import random
 
+from arsenal.strategy import base as sb
+from arsenal.strategy import simple_proportional_strategy as sps
 from arsenal.tests import base as test_base
 
-from arsenal.strategy.simple_proportional_strategy import SimpleProportionalStrategy, available_nodes
-from arsenal.strategy.base import *
-
 random.seed()
+
 
 def name_starts_with(node, letter):
     return node.node_uuid[0] == letter
 
+
 TEST_FLAVORS = [
-    FlavorInput("IO", lambda node: name_starts_with(node, 'i')),
-    FlavorInput("Compute", lambda node: name_starts_with(node, 'c')),
-    FlavorInput("Memory", lambda node: name_starts_with(node, 'm')),
+    sb.FlavorInput("IO", lambda node: name_starts_with(node, 'i')),
+    sb.FlavorInput("Compute", lambda node: name_starts_with(node, 'c')),
+    sb.FlavorInput("Memory", lambda node: name_starts_with(node, 'm')),
 ]
 
 TEST_IMAGES = [
-    ImageInput("Ubuntu", "aaaa"),
-    ImageInput("CentOS", "bbbb"),
-    ImageInput("CoreOS", "cccc"),
-    ImageInput("Redhat", "dddd"),
-    ImageInput("Windows", "eeee")
+    sb.ImageInput("Ubuntu", "aaaa"),
+    sb.ImageInput("CentOS", "bbbb"),
+    sb.ImageInput("CoreOS", "cccc"),
+    sb.ImageInput("Redhat", "dddd"),
+    sb.ImageInput("Windows", "eeee")
 ]
+
 
 class TestSimpleProportionalStrategy(test_base.TestCase):
 
@@ -53,83 +55,85 @@ class TestSimpleProportionalStrategy(test_base.TestCase):
         # Setup a few simple cases, that are mostly defaults.
         self.environments = {
             'one_unprovisioned_node_environment': {
-                'nodes': [NodeInput("caaa", False, False, None)],
+                'nodes': [sb.NodeInput("caaa", False, False, None)],
             },
             'one_provisioned_node_environment': {
-                'nodes': [NodeInput("caaa", True, False, None)],
+                'nodes': [sb.NodeInput("caaa", True, False, None)],
             },
             'two_node_environment': {
                 'nodes': [
-                    NodeInput("caaa", False, False, None),
-                    NodeInput("cbbb", False, False, None),
+                    sb.NodeInput("caaa", False, False, None),
+                    sb.NodeInput("cbbb", False, False, None),
                 ],
             }
         }
 
-        # Some programmatically constructed. With random provision and 
+        # Some programmatically constructed. With random provision and
         # cached states.
         node_counts = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144]
         flavor_prefixes = ['i', 'c', 'm']
         for n_count in node_counts:
-            environment = { 'nodes': [] } 
+            environment = {'nodes': []}
             for n in range(n_count):
                 flavor_pick = random.choice(flavor_prefixes)
                 image_pick_uuid = random.choice(TEST_IMAGES).uuid
                 environment['nodes'].append(
-                        NodeInput("%s-%d" % (flavor_pick, n), 
-                            random.randint(0,1),
-                            random.randint(0,1),
-                            image_pick_uuid))
+                    sb.NodeInput("%s-%d" % (flavor_pick, n),
+                                 random.randint(0, 1),
+                                 random.randint(0, 1),
+                                 image_pick_uuid))
             self.environments["random-nodes(%d)" % n_count] = environment
-            
+
         # Defaults
         for env_name, env_dict in self.environments.iteritems():
             env_dict['flavors'] = TEST_FLAVORS
             env_dict['images'] = TEST_IMAGES
 
-
     def test_determine_minimum_nodes_needed_to_cache(self):
-        # self.assertTrue(False, "TODO")
+        # self.assertTrue(False, "TODO(ClifHouck)")
         pass
 
     def test_determine_number_of_nodes_that_should_cache(self):
-        # self.assertTrue(False, "TODO")
+        # self.assertTrue(False, "TODO(ClifHouck)")
         pass
-        
+
     def test_proportion_goal_versus_several_percentages(self):
-        print "Starting test_proportion_goal_versus_several_percentages."
+        print("Starting test_proportion_goal_versus_several_percentages.")
         percentages = [0, 10, 25, 50, 75, 90, 100]
         for percent in percentages:
-            print ("Trying %d percent." % percent)
+            print("Trying %d percent." % percent)
             self._test_proportion_goal(percent)
 
     def _test_proportion_goal(self, test_percentage=50):
         """Test that strategy goals are always being met by directives output.
-        Are we always caching at least enough to hit our proportion goal."""
-        strategy = SimpleProportionalStrategy(test_percentage)
+        Are we always caching at least enough to hit our proportion goal.
+        """
+        strategy = sps.SimpleProportionalStrategy(test_percentage)
         for env_name, env in self.environments.iteritems():
-            print "Testing %s environment." % env_name
+            print("Testing %s environment." % env_name)
             strategy.update_current_state(**env)
             directives = strategy.directives()
-            available_node_count = len(available_nodes(env['nodes']))
-            cached_node_count = len(filter(lambda node: node.cached, 
-                env['nodes']))
+            available_node_count = len(sps.available_nodes(env['nodes']))
+            cached_node_count = len(filter(lambda node: node.cached,
+                                           env['nodes']))
             cache_directive_count = len(filter(
-                lambda directive: isinstance(directive, CacheNode), 
+                lambda directive: isinstance(directive, sb.CacheNode),
                 directives))
-            self.assertTrue(cache_directive_count <= available_node_count, 
-                    ("There shouldn't be more cache directives than there are "
-                     "nodes available to cache."))
+            self.assertTrue(cache_directive_count <= available_node_count,
+                            ("There shouldn't be more cache directives than "
+                             "there are nodes available to cache."))
 
             total_percent_cached = 0
             if available_node_count != 0:
-                total_percent_cached = (cache_directive_count + 
-                    cached_node_count) / available_node_count
-                self.assertTrue(total_percent_cached >= test_percentage/100, (
+                total_percent_cached = (
+                    cache_directive_count + cached_node_count) / (
+                    available_node_count)
+                self.assertTrue((
+                    total_percent_cached >= test_percentage / 100), (
                     "The number of cache directives emitted by the strategy "
                     "does not fulfill the goal! Total percent to be "
                     "cached: %f, expected %f" % (total_percent_cached,
-                        test_percentage/100)))
+                                                 test_percentage / 100)))
             else:
                 self.assertTrue(cache_directive_count == 0, (
                     "Since there are no available nodes to cache, the number "
@@ -139,10 +143,11 @@ class TestSimpleProportionalStrategy(test_base.TestCase):
     def test_node_ejection_behavior(self):
         """Perform the ejection test for all test environments."""
         for env_name, env in self.environments.iteritems():
-            print "Testing ejection behavior for '%s'." % env_name
+            print("Testing ejection behavior for '%s'." % env_name)
             self._ejection_test(env)
 
     def _ejection_test(self, env):
-        """Are we ejecting nodes whose images are no longer in the current 
-        image list?"""
+        """Are we ejecting nodes whose images are no longer in the current
+        image list?
+        """
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ commands = python setup.py build_sphinx
 # H803 skipped on purpose per list discussion.
 # E123, E125 skipped as they are invalid PEP-8.
 
+
 show-source = True
-ignore = E123,E125,H803
+ignore = E123,E125,H803,H405
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build


### PR DESCRIPTION
Includes an abstract base class for objects to implement to help support pluggable caching strategies.

Main work centers around implementing and testing a simple proportional caching strategy. In short, the strategy will always attempt to cache a given percentage of unprovisioned nodes. This is a bit rough, there's some extraneous code, and some refactoring that should be done. I probably need a couple of more tests to further codify the expected behavior out of the strategy and make sure it will behave sanely in production.