### PR TITLE
Fix proportional strategy and tests

### DIFF
--- a/arsenal/strategy/base.py
+++ b/arsenal/strategy/base.py
@@ -27,7 +27,8 @@ class StrategyInput(object):
 
 
 class NodeInput(StrategyInput):
-    def __init__(self, node_uuid, is_provisioned, is_cached, image_uuid):
+    def __init__(self, node_uuid, is_provisioned=False, is_cached=False,
+                 image_uuid=''):
         super(NodeInput, self).__init__()
         self.node_uuid = node_uuid
         self.provisioned = is_provisioned
@@ -37,7 +38,13 @@ class NodeInput(StrategyInput):
     def can_cache(self):
         # If the node is not provisioned and not already caching an image,
         # then it is available for caching.
-        return not self.provisioned and not self.cached
+        return (not self.provisioned) and (not self.cached)
+
+    def __str__(self):
+        return "[NodeInput]: %s, %s, %s, %s" % (self.node_uuid, 
+                "Provisioned" if self.provisioned else "Unprovisioned",
+                "Cached" if self.cached else "Not cached",
+                self.cached_image_uuid)
 
 
 class FlavorInput(StrategyInput):
@@ -46,6 +53,9 @@ class FlavorInput(StrategyInput):
         self.name = name
         self.is_flavor_node = identity_func
 
+    def __str__(self):
+        return "[FlavorInput]: %s" % (self.name)
+
 
 class ImageInput(StrategyInput):
     def __init__(self, name, uuid):
@@ -53,11 +63,15 @@ class ImageInput(StrategyInput):
         self.name = name
         self.uuid = uuid
 
+    def __str__(self):
+        return "[ImageInput]: %s, %s" % (self.name, self.uuid)
 
 class StrategyAction(object):
     """Base class for actions a CachingStratgy object may take."""
     def __init__(self, format_string="{0}", format_attrs=['name']):
         self.name = self.__class__.__name__
+        self.format_string = format_string
+        self.format_attrs = format_attrs
 
     def __str__(self):
         format_list = []
@@ -73,7 +87,7 @@ class CacheNode(StrategyAction):
 
     def __init__(self, node_uuid, image_uuid):
         super(CacheNode, self).__init__(
-            format_string="{0}: Cache image '{1}' on node '{0}'.",
+            format_string="{0}: Cache image '{1}' on node '{2}'.",
             format_attrs=['name', 'image_uuid', 'node_uuid'])
         self.node_uuid = node_uuid
         self.image_uuid = image_uuid

--- a/arsenal/strategy/base.py
+++ b/arsenal/strategy/base.py
@@ -41,10 +41,11 @@ class NodeInput(StrategyInput):
         return (not self.provisioned) and (not self.cached)
 
     def __str__(self):
-        return "[NodeInput]: %s, %s, %s, %s" % (self.node_uuid, 
-                "Provisioned" if self.provisioned else "Unprovisioned",
-                "Cached" if self.cached else "Not cached",
-                self.cached_image_uuid)
+        return "[NodeInput]: %s, %s, %s, %s" % (
+            self.node_uuid,
+            "Provisioned" if self.provisioned else "Unprovisioned",
+            "Cached" if self.cached else "Not cached",
+            self.cached_image_uuid)
 
 
 class FlavorInput(StrategyInput):
@@ -65,6 +66,7 @@ class ImageInput(StrategyInput):
 
     def __str__(self):
         return "[ImageInput]: %s, %s" % (self.name, self.uuid)
+
 
 class StrategyAction(object):
     """Base class for actions a CachingStratgy object may take."""

--- a/arsenal/strategy/simple_proportional_strategy.py
+++ b/arsenal/strategy/simple_proportional_strategy.py
@@ -15,6 +15,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import division
 import math
 import random
 
@@ -51,8 +52,16 @@ def build_attribute_dict(items, attr_name):
     return attr_dict
 
 
-def available_nodes(nodes):
+def nodes_available_for_caching(nodes):
     return filter(lambda node: node.can_cache(), nodes)
+
+
+def cached_nodes(nodes):
+    return filter(lambda node: not node.provisioned and node.cached, nodes)
+
+
+def unprovisioned_nodes(nodes):
+    return filter(lambda node: not node.provisioned, nodes)
 
 
 def segregate_nodes(nodes, flavors):
@@ -67,7 +76,7 @@ def segregate_nodes(nodes, flavors):
 
 
 def eject_nodes(nodes, image_uuids):
-    """For each flavor, check for cached nodes that have old or
+    """Check for cached nodes that have old or
     retired images. Eject them, and mark them as uncached internally.
     """
     ejections = []
@@ -82,9 +91,15 @@ def eject_nodes(nodes, image_uuids):
 
 
 def cache_nodes(nodes, num_nodes_needed, images):
-    nodes_available_for_caching = available_nodes(nodes)
-    print("num_nodes_needed: %d, nodes_available_for_caching: %d" % (
-          num_nodes_needed, len(nodes_available_for_caching)))
+    available_nodes = nodes_available_for_caching(nodes)
+
+    print("num_nodes_needed: %d, available_nodes: %d" % (
+          num_nodes_needed, len(available_nodes)))
+
+    if num_nodes_needed > len(available_nodes):
+        LOG.info(("SimpleProportionalStrategy: The number of nodes needed to "
+            "reach the proportional goal "))
+        num_nodes_needed = len(available_nodes)
 
     # If we're not meeting or exceeding
     # our proportion goal, schedule (node, image) pairs to cache
@@ -92,36 +107,40 @@ def cache_nodes(nodes, num_nodes_needed, images):
     # TODO(ClifHouck): This selection step can probably be
     # improved.
     nodes_to_cache = []
-    random.shuffle(nodes_available_for_caching)
+    random.shuffle(available_nodes)
     for n in range(0, num_nodes_needed):
-        node = nodes_available_for_caching.pop()
+        node = available_nodes.pop()
         image = random.choice(images)
         nodes_to_cache.append(sb.CacheNode(node.node_uuid, image.uuid))
     return nodes_to_cache
 
 
 def min_nodes_to_cache(nodes, percentage_to_cache):
-    num_nodes_cached = len(filter(lambda node: node.cached, nodes))
+    test_var = cached_nodes(nodes)
+    num_nodes_cached = len(cached_nodes(nodes))
     num_should_cache = how_many_nodes_should_cache(nodes, percentage_to_cache)
-    num_needed = num_should_cache - num_nodes_cached
-    return num_needed
+    print (("min_nodes_to_cache: goal = %f, available = %d, cached = %d, "
+        "should_cache = %d, unprovisioned = %d") % (percentage_to_cache, 
+            len(nodes_available_for_caching(nodes)), num_nodes_cached, 
+            num_should_cache, len(unprovisioned_nodes(nodes))))
+    return num_should_cache
 
 
 def how_many_nodes_should_cache(nodes, percentage_to_cache):
-    return int(math.ceil(
-        0.01 * percentage_to_cache * len(available_nodes(nodes))))
+    return int(math.ceil(percentage_to_cache * len(
+        unprovisioned_nodes(nodes)))) - len(cached_nodes(nodes))
 
 
 class InvalidPercentageError(exception.ArsenalException):
     msg_fmt = ("An invalid percentage was specified. Percentages should be "
-               "less than or equal to 100, and greater than or equal to 0. "
+               "less than or equal to 1, and greater than or equal to 0. "
                "Got '%(percentage)f'.")
 
 
 class SimpleProportionalStrategy(object):
-    def __init__(self, percentage_to_cache=25):
+    def __init__(self, percentage_to_cache=0.25):
         # Clamp the percentage to reasonable values.
-        if percentage_to_cache < 0 or percentage_to_cache > 100:
+        if percentage_to_cache < 0 or percentage_to_cache > 1:
             raise InvalidPercentageError(percentage=percentage_to_cache)
 
         self.percentage_to_cache = percentage_to_cache
@@ -159,7 +178,8 @@ class SimpleProportionalStrategy(object):
         todo = []
 
         # Eject nodes.
-        todo.extend(eject_nodes(self.current_nodes, self.current_images))
+        todo.extend(eject_nodes(self.current_nodes, 
+            map(lambda image: image.uuid, self.current_images)))
 
         # Once bad cached nodes have been ejected, determine the proportion
         # of truly 'good' cached nodes.

--- a/arsenal/tests/strategy/test_simple_proportional_strategy.py
+++ b/arsenal/tests/strategy/test_simple_proportional_strategy.py
@@ -78,7 +78,7 @@ class TestSimpleProportionalStrategy(test_base.TestCase):
         images_with_invalid.extend(TEST_IMAGES)
         images_with_invalid.append(INVALID_IMAGE)
         for n_count in node_counts:
-            print "Building random nodes for random-nodes(%d)" % n_count
+            print("Building random nodes for random-nodes(%d)" % n_count)
             environment = {'nodes': []}
             for n in range(n_count):
                 flavor_pick = random.choice(flavor_prefixes)
@@ -122,22 +122,25 @@ class TestSimpleProportionalStrategy(test_base.TestCase):
             for directive in directives:
                 print(str(directive))
             for flavor in env['flavors']:
-                self._test_proportion_goal_versus_flavor(strategy, directives,
-                        env['nodes'], flavor)
+                self._test_proportion_goal_versus_flavor(
+                    strategy, directives, env['nodes'], flavor)
 
-    def _test_proportion_goal_versus_flavor(self, strat, directives, nodes, 
-            flavor):
+    def _test_proportion_goal_versus_flavor(self, strat, directives, nodes,
+                                            flavor):
         print("Testing flavor %s." % flavor.name)
         flavor_nodes = filter(lambda node: flavor.is_flavor_node(node), nodes)
         unprovisioned_node_count = len(sps.unprovisioned_nodes(flavor_nodes))
         available_node_count = len(sps.nodes_available_for_caching(
             flavor_nodes))
         cached_node_count = len(filter(lambda node: node.cached, flavor_nodes))
-        cache_directive_count = len(filter(
-            lambda directive: (isinstance(directive, sb.CacheNode) and 
-                flavor.is_flavor_node(
-                    sb.NodeInput(directive.node_uuid))), directives))
-        self.assertTrue(cache_directive_count <= available_node_count,
+        cache_directive_count = len(
+            filter(
+                lambda directive: (
+                    isinstance(directive, sb.CacheNode) and
+                    flavor.is_flavor_node(sb.NodeInput(directive.node_uuid))),
+                directives))
+        self.assertTrue(
+            cache_directive_count <= available_node_count,
             ("There shouldn't be more cache directives than "
              "there are nodes available to cache."))
 


### PR DESCRIPTION
This fixes the behavior in SimpleProportionalStrategy to correctly cache a proportion of unprovisioned nodes per flavor, rather than just nodes available for caching. So it properly accounts for already cached nodes.

Also changed the percentage variable to be between 0 and 1, instead of between 0 and 100. For science!

Tests have also been fixed to test the proportional goal per flavor rather than against the entire pool of nodes at once.