### PR TITLE
Refactored client wrappers

### DIFF
--- a/arsenal/external/client_wrapper.py
+++ b/arsenal/external/client_wrapper.py
@@ -1,0 +1,175 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Rackspace
+# Copyright 2014 Hewlett-Packard Development Company, L.P.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import time
+
+from oslo.config import cfg
+import six
+
+from arsenal.common import exception
+from arsenal.openstack.common import log as logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+opts = [
+    cfg.StrOpt('os_username',
+               help='Openstack keystone admin name'),
+    cfg.StrOpt('os_password',
+               help='Openstack keystone admin password.'),
+    cfg.StrOpt('os_auth_token',
+               help='Openstack keystone auth token.'),
+    cfg.StrOpt('os_api_url',
+               help='Keystone public API endpoint.'),
+    cfg.StrOpt('os_tenant_name',
+               help='Openstack keystone tenant name.'),
+    cfg.IntOpt('call_max_retries',
+               default=60,
+               help='How many times to retry a call when the call fails in '
+                    'some recoverable way.'),
+    cfg.IntOpt('call_retry_interval',
+               default=2,
+               help='How often to retry in seconds when a request '
+                    'fails in some recoverable way.'),
+    cfg.StrOpt('region_name',
+               help='Openstack region name.'),
+    cfg.StrOpt('service_name',
+               help='Openstack service name.'),
+    cfg.StrOpt('auth_system',
+               default='keystone',
+               help='Openstack auth_system argument.'),
+]
+
+client_wrapper_group = cfg.OptGroup(name='client_wrapper',
+                                    title='Configuration for the Openstack '
+                                          'client wrapper.')
+
+CONF = cfg.CONF
+CONF.register_group(client_wrapper_group)
+CONF.register_opts(opts, client_wrapper_group)
+
+
+def first_not_none(iterable):
+    """Select the first item from an iterable that is not None.
+
+    The idea is that you can use this to specify a list of fall-backs to use
+    for configuration options.
+    """
+    for item in iterable:
+        if item is not None:
+            return item
+    return None
+
+
+@six.add_metaclass(abc.ABCMeta)
+class OpenstackClientWrapper(object):
+    """An abstract interface for wrapping an Openstack client.
+
+        """
+    def __init__(self,
+                 retry_exceptions,
+                 auth_exceptions,
+                 name="Openstack"):
+        """Initialise the OpenstackClientWrapper for use.
+
+        :param retry_exceptions: A tuple of default client exceptions which
+            should cause the call method to be retried.
+        :param auth_exceptions: A tuple of default client exceptions which
+            should cause the call method wrapper to attempt to reauthorize the
+            client.
+        :param name: The name of the client.
+        """
+        self._cached_client = None
+        self.name = name
+        self.retry_exceptions = retry_exceptions
+        self.auth_exceptions = auth_exceptions
+
+    def _invalidate_cached_client(self):
+        """Tell the wrapper to invalidate the cached client."""
+        self._cached_client = None
+
+    @abc.abstractmethod
+    def _get_new_client(self):
+        """Provides an abstract way to access the wrapped client."""
+        pass
+
+    def _get_client(self):
+        """Gets the wrapped client."""
+        if self._cached_client is None:
+            self._cached_client = self._get_new_client()
+        return self._cached_client
+
+    def _multi_getattr(self, obj, attr):
+        """Support nested attribute path for getattr().
+
+        :param obj: Root object.
+        :param attr: Path of final attribute to get. E.g., "a.b.c.d"
+
+        :returns: The value of the final named attribute.
+        :raises: AttributeError will be raised if the path is invalid.
+        """
+        for attribute in attr.split("."):
+            obj = getattr(obj, attribute)
+        return obj
+
+    def call(self, method, *args, **kwargs):
+        """Call the specified client method and retry on errors.
+
+        :param method: Name of the client method to call as a string.
+        :param args: Client method arguments.
+        :param kwargs: Client method keyword arguments.
+
+        :raises: ArsenalException if all retries failed.
+        """
+        retry_exceptions = self.retry_exceptions
+        auth_exceptions = self.auth_exceptions
+        max_retries = CONF.client_wrapper.call_max_retries
+        retry_interval = CONF.client_wrapper.call_retry_interval
+
+        for attempt in range(1, max_retries + 1):
+            client = self._get_client()
+
+            try:
+                return self._multi_getattr(client, method)(*args, **kwargs)
+            except auth_exceptions:
+                # In this case, the authorization token of the cached
+                # client probably expired. So invalidate the cached
+                # client and the next try will start with a fresh one.
+                self._invalidate_cached_client()
+                LOG.debug("The wrapped %(name)s client became unauthorized. "
+                          "Will attempt to reauthorize and try again." % {
+                              'name': self.name})
+            except retry_exceptions as e:
+                LOG.debug("Got a retry-able exception." + str(e))
+                pass
+
+            # We want to perform this logic for all exception cases listed
+            # above.
+            msg = ("Error contacting %(name)s server for "
+                   "'%(method)s'. Attempt %(attempt)d of %(total)d" %
+                   {'name': self.name,
+                    'method': method,
+                    'attempt': attempt,
+                    'total': max_retries})
+            if attempt == max_retries:
+                LOG.error(msg)
+                raise exception.ArsenalException(msg)
+            LOG.warning(msg)
+            time.sleep(retry_interval)

--- a/arsenal/external/ironic_client_wrapper.py
+++ b/arsenal/external/ironic_client_wrapper.py
@@ -19,12 +19,11 @@
 # https://github.com/openstack/nova/ in ./nova/virt/ironic/client_wrapper.py
 # and slightly adapted for Arsenal
 
-import time
-
+import ironicclient
 from oslo.config import cfg
-from oslo.utils import importutils
 
 from arsenal.common import exception
+from arsenal.external import client_wrapper
 # from arsenal.i18n import _
 from arsenal.openstack.common import log as logging
 
@@ -68,117 +67,53 @@ CONF = cfg.CONF
 CONF.register_group(ironic_group)
 CONF.register_opts(opts, ironic_group)
 
-ironic = None
+first_not_none = client_wrapper.first_not_none
 
 
-class IronicClientWrapper(object):
+class IronicClientWrapper(client_wrapper.OpenstackClientWrapper):
     """Ironic client wrapper class that encapsulates retry logic."""
 
     def __init__(self):
-        """Initialise the IronicClientWrapper for use.
+        """Initialise the IronicClientWrapper for use."""
+        super(IronicClientWrapper, self).__init__(
+            retry_exceptions=(ironicclient.exc.ServiceUnavailable,
+                              ironicclient.exc.ConnectionRefused,
+                              ironicclient.exc.Conflict),
+            auth_exceptions=(ironicclient.exc.Unauthorized),
+            name="Ironic")
 
-        Initialise IronicClientWrapper by loading ironicclient
-        dynamically so that ironicclient is not a dependency for
-        Arsenal.
-        """
-        global ironic
-        if ironic is None:
-            ironic = importutils.import_module('ironicclient')
-            # NOTE(deva): work around a lack of symbols in the current version.
-            if not hasattr(ironic, 'exc'):
-                ironic.exc = importutils.import_module('ironicclient.exc')
-            if not hasattr(ironic, 'client'):
-                ironic.client = importutils.import_module(
-                    'ironicclient.client')
-        self._cached_client = None
+    def _get_new_client(self):
+        auth_token = first_not_none([CONF.ironic.admin_auth_token,
+                                     CONF.client_wrapper.os_auth_token])
 
-    def _invalidate_cached_client(self):
-        """Tell the wrapper to invalidate the cached ironic-client."""
-        self._cached_client = None
-
-    def _get_client(self):
-        # If we've already constructed a valid, authed client, just return
-        # that.
-        if self._cached_client is not None:
-            return self._cached_client
-
-        auth_token = CONF.ironic.admin_auth_token
         if auth_token is None:
-            kwargs = {'os_username': CONF.ironic.admin_username,
-                      'os_password': CONF.ironic.admin_password,
-                      'os_auth_url': CONF.ironic.admin_url,
-                      'os_tenant_name': CONF.ironic.admin_tenant_name,
+            kwargs = {'os_username':
+                      first_not_none([CONF.ironic.admin_username,
+                                      CONF.client_wrapper.os_username]),
+                      'os_password':
+                      first_not_none([CONF.ironic.admin_password,
+                                      CONF.client_wrapper.os_password]),
+                      'os_auth_url':
+                      first_not_none([CONF.ironic.admin_url,
+                                      CONF.client_wrapper.os_api_url]),
+                      'os_tenant_name':
+                      first_not_none([CONF.ironic.admin_tenant_name,
+                                      CONF.client_wrapper.os_tenant_name]),
                       'os_service_type': 'baremetal',
                       'os_endpoint_type': 'public',
-                      'ironic_url': CONF.ironic.api_endpoint}
+                      'ironic_url': CONF.ironic.api_endpoint
+                      }
         else:
             kwargs = {'os_auth_token': auth_token,
-                      'ironic_url': CONF.ironic.api_endpoint}
+                      'ironic_url': CONF.client_wrapper.os_api_url}
 
         try:
-            cli = ironic.client.get_client(CONF.ironic.api_version, **kwargs)
-            # Cache the client so we don't have to reconstruct and
-            # reauthenticate it every time we need it.
-            self._cached_client = cli
+            cli = ironicclient.client.get_client(CONF.ironic.api_version,
+                                                 **kwargs)
 
-        except ironic.exc.Unauthorized:
+        except ironicclient.exc.Unauthorized:
             msg = "Unable to authenticate Ironic client."
             LOG.error(msg)
             raise exception.ArsenalException(msg)
 
         return cli
-
-    def _multi_getattr(self, obj, attr):
-        """Support nested attribute path for getattr().
-
-        :param obj: Root object.
-        :param attr: Path of final attribute to get. E.g., "a.b.c.d"
-
-        :returns: The value of the final named attribute.
-        :raises: AttributeError will be raised if the path is invalid.
-        """
-        for attribute in attr.split("."):
-            obj = getattr(obj, attribute)
-        return obj
-
-    def call(self, method, *args, **kwargs):
-        """Call an Ironic client method and retry on errors.
-
-        :param method: Name of the client method to call as a string.
-        :param args: Client method arguments.
-        :param kwargs: Client method keyword arguments.
-
-        :raises: ArsenalException if all retries failed.
-        """
-        retry_excs = (ironic.exc.ServiceUnavailable,
-                      ironic.exc.ConnectionRefused,
-                      ironic.exc.Conflict)
-        num_attempts = CONF.ironic.api_max_retries
-
-        for attempt in range(1, num_attempts + 1):
-            client = self._get_client()
-
-            try:
-                return self._multi_getattr(client, method)(*args, **kwargs)
-            except ironic.exc.Unauthorized:
-                # In this case, the authorization token of the cached
-                # ironic-client probably expired. So invalidate the cached
-                # client and the next try will start with a fresh one.
-                self._invalidate_cached_client()
-                LOG.debug("The Ironic client became unauthorized. "
-                          "Will attempt to reauthorize and try again.")
-            except retry_excs:
-                pass
-
-            # We want to perform this logic for all exception cases listed
-            # above.
-            msg = ("Error contacting Ironic server for "
-                   "'%(method)s'. Attempt %(attempt)d of %(total)d" %
-                   {'method': method,
-                    'attempt': attempt,
-                    'total': num_attempts})
-            if attempt == num_attempts:
-                LOG.error(msg)
-                raise exception.ArsenalException(msg)
-            LOG.warning(msg)
-            time.sleep(CONF.ironic.api_retry_interval)

--- a/arsenal/tests/external/test_client_wrapper.py
+++ b/arsenal/tests/external/test_client_wrapper.py
@@ -1,0 +1,148 @@
+# Copyright 2014 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+from oslo.config import cfg
+
+from arsenal.common import exception
+from arsenal.external import client_wrapper
+from arsenal.tests import base as test_base
+
+
+CONF = cfg.CONF
+
+
+class FakeFlavorClient(object):
+    def list(self, detail=False):
+        return []
+
+
+class FakeClient(object):
+    flavor = FakeFlavorClient()
+
+
+def get_new_fake_client(*args, **kwargs):
+    return FakeClient()
+
+
+class FakeUnauthorizedException(Exception):
+    pass
+
+
+class FakeRetryOnThisException(Exception):
+    pass
+
+
+class FakeUnexpectedException(Exception):
+    pass
+
+
+class FakeClientWrapper(client_wrapper.OpenstackClientWrapper):
+
+    def __init__(self):
+        super(FakeClientWrapper, self).__init__(
+            retry_exceptions=(FakeRetryOnThisException),
+            auth_exceptions=(FakeUnauthorizedException),
+            name="FakeClient")
+
+    def _get_new_client(self):
+        return get_new_fake_client()
+
+
+FAKE_CLIENT = FakeClient()
+
+
+class OpenstackClientWrapperTestCase(test_base.TestCase):
+
+    def setUp(self):
+        super(OpenstackClientWrapperTestCase, self).setUp()
+        # Yes, the client is fake, but we're only testing relevant behavior
+        # in the base class.
+        self.openstackclient = FakeClientWrapper()
+        # Do not waste time sleeping
+        cfg.CONF.set_override('call_retry_interval', 0, 'client_wrapper')
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, '_multi_getattr')
+    @mock.patch.object(FakeClientWrapper, '_get_new_client')
+    def test_call_good_no_args(self, mock_get_new_client, mock_multi_getattr):
+        mock_get_new_client.return_value = FAKE_CLIENT
+        self.openstackclient.call("flavor.list")
+        mock_get_new_client.assert_called_once_with()
+        mock_multi_getattr.assert_called_once_with(FAKE_CLIENT, "flavor.list")
+        mock_multi_getattr.return_value.assert_called_once_with()
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, '_multi_getattr')
+    @mock.patch.object(FakeClientWrapper, '_get_new_client')
+    def test_call_good_with_args(self, mock_get_client, mock_multi_getattr):
+        mock_get_client.return_value = FAKE_CLIENT
+        self.openstackclient.call("flavor.list", 'test', associated=True)
+        mock_get_client.assert_called_once_with()
+        mock_multi_getattr.assert_called_once_with(FAKE_CLIENT, "flavor.list")
+        mock_multi_getattr.return_value.assert_called_once_with(
+            'test', associated=True)
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, '_multi_getattr')
+    @mock.patch.object(FakeClientWrapper, '_get_new_client')
+    def test_call_fail(self, mock_get_new_client, mock_multi_getattr):
+        cfg.CONF.set_override('call_max_retries', 2, 'client_wrapper')
+        test_obj = mock.Mock()
+        test_obj.side_effect = (FakeRetryOnThisException('ConnectionRefused'))
+        mock_multi_getattr.return_value = test_obj
+        mock_get_new_client.return_value = FAKE_CLIENT
+        self.assertRaises(exception.ArsenalException,
+                          self.openstackclient.call,
+                          "flavor.list")
+        self.assertEqual(2, test_obj.call_count)
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, '_multi_getattr')
+    @mock.patch.object(FakeClientWrapper, '_get_new_client')
+    def test_call_fail_unexpected_exception(self, mock_get_new_client,
+                                            mock_multi_getattr):
+        test_obj = mock.Mock()
+        test_obj.side_effect = FakeUnexpectedException('NotFound')
+        mock_multi_getattr.return_value = test_obj
+        mock_get_new_client.return_value = FAKE_CLIENT
+        self.assertRaises(FakeUnexpectedException,
+                          self.openstackclient.call, "flavor.list")
+
+    def test__multi_getattr_good(self):
+        response = self.openstackclient._multi_getattr(FAKE_CLIENT,
+                                                       "flavor.list")
+        self.assertEqual(FAKE_CLIENT.flavor.list, response)
+
+    def test__multi_getattr_fail(self):
+        self.assertRaises(AttributeError, self.openstackclient._multi_getattr,
+                          FAKE_CLIENT, "nonexistent")
+
+    def test__client_is_cached(self):
+        openstackclient = FakeClientWrapper()
+        first_client = openstackclient._get_client()
+        second_client = openstackclient._get_client()
+        self.assertEqual(id(first_client), id(second_client))
+
+    def test__invalidate_cached_client(self):
+        openstackclient = FakeClientWrapper()
+        first_client = openstackclient._get_client()
+        openstackclient._invalidate_cached_client()
+        second_client = openstackclient._get_client()
+        self.assertNotEqual(id(first_client), id(second_client))
+
+    @mock.patch.object(FakeClientWrapper, '_get_new_client')
+    def test_call_uses_cached_client(self, mock_get_new_client):
+        mock_get_new_client.side_effect = lambda: get_new_fake_client()
+        openstackclient = FakeClientWrapper()
+        for n in range(0, 4):
+            openstackclient.call("flavor.list")
+        self.assertEqual(1, mock_get_new_client.call_count)

--- a/arsenal/tests/external/test_ironic_client_wrapper.py
+++ b/arsenal/tests/external/test_ironic_client_wrapper.py
@@ -14,11 +14,9 @@
 #    under the License.
 
 from ironicclient import client as ironic_client
-from ironicclient import exc as ironic_exception
 import mock
 from oslo.config import cfg
 
-from arsenal.common import exception
 from arsenal.external import ironic_client_wrapper as client_wrapper
 from arsenal.tests import base as test_base
 from arsenal.tests.external import ironic_utils
@@ -38,26 +36,7 @@ class IronicClientWrapperTestCase(test_base.TestCase):
         super(IronicClientWrapperTestCase, self).setUp()
         self.ironicclient = client_wrapper.IronicClientWrapper()
         # Do not waste time sleeping
-        cfg.CONF.set_override('api_retry_interval', 0, 'ironic')
-
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_multi_getattr')
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_get_client')
-    def test_call_good_no_args(self, mock_get_client, mock_multi_getattr):
-        mock_get_client.return_value = FAKE_CLIENT
-        self.ironicclient.call("node.list")
-        mock_get_client.assert_called_once_with()
-        mock_multi_getattr.assert_called_once_with(FAKE_CLIENT, "node.list")
-        mock_multi_getattr.return_value.assert_called_once_with()
-
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_multi_getattr')
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_get_client')
-    def test_call_good_with_args(self, mock_get_client, mock_multi_getattr):
-        mock_get_client.return_value = FAKE_CLIENT
-        self.ironicclient.call("node.list", 'test', associated=True)
-        mock_get_client.assert_called_once_with()
-        mock_multi_getattr.assert_called_once_with(FAKE_CLIENT, "node.list")
-        mock_multi_getattr.return_value.assert_called_once_with(
-            'test', associated=True)
+        cfg.CONF.set_override('call_retry_interval', 0, 'client_wrapper')
 
     @mock.patch.object(ironic_client, 'get_client')
     def test__get_client_no_auth_token(self, mock_ir_cli):
@@ -85,71 +64,3 @@ class IronicClientWrapperTestCase(test_base.TestCase):
                     'ironic_url': CONF.ironic.api_endpoint}
         mock_ir_cli.assert_called_once_with(CONF.ironic.api_version,
                                             **expected)
-
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_multi_getattr')
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_get_client')
-    def test_call_fail(self, mock_get_client, mock_multi_getattr):
-        cfg.CONF.set_override('api_max_retries', 2, 'ironic')
-        test_obj = mock.Mock()
-        test_obj.side_effect = ironic_exception.HTTPServiceUnavailable
-        mock_multi_getattr.return_value = test_obj
-        mock_get_client.return_value = FAKE_CLIENT
-        self.assertRaises(exception.ArsenalException, self.ironicclient.call,
-                          "node.list")
-        self.assertEqual(2, test_obj.call_count)
-
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_multi_getattr')
-    @mock.patch.object(client_wrapper.IronicClientWrapper, '_get_client')
-    def test_call_fail_unexpected_exception(self, mock_get_client,
-                                            mock_multi_getattr):
-        test_obj = mock.Mock()
-        test_obj.side_effect = ironic_exception.HTTPNotFound
-        mock_multi_getattr.return_value = test_obj
-        mock_get_client.return_value = FAKE_CLIENT
-        self.assertRaises(ironic_exception.HTTPNotFound,
-                          self.ironicclient.call, "node.list")
-
-    @mock.patch.object(ironic_client, 'get_client')
-    def test__get_client_unauthorized(self, mock_get_client):
-        mock_get_client.side_effect = ironic_exception.Unauthorized
-        self.assertRaises(exception.ArsenalException,
-                          self.ironicclient._get_client)
-
-    @mock.patch.object(ironic_client, 'get_client')
-    def test__get_client_unexpected_exception(self, mock_get_client):
-        mock_get_client.side_effect = ironic_exception.ConnectionRefused
-        self.assertRaises(ironic_exception.ConnectionRefused,
-                          self.ironicclient._get_client)
-
-    def test__multi_getattr_good(self):
-        response = self.ironicclient._multi_getattr(FAKE_CLIENT, "node.list")
-        self.assertEqual(FAKE_CLIENT.node.list, response)
-
-    def test__multi_getattr_fail(self):
-        self.assertRaises(AttributeError, self.ironicclient._multi_getattr,
-                          FAKE_CLIENT, "nonexistent")
-
-    @mock.patch.object(ironic_client, 'get_client')
-    def test__client_is_cached(self, mock_get_client):
-        mock_get_client.side_effect = get_new_fake_client
-        ironicclient = client_wrapper.IronicClientWrapper()
-        first_client = ironicclient._get_client()
-        second_client = ironicclient._get_client()
-        self.assertEqual(id(first_client), id(second_client))
-
-    @mock.patch.object(ironic_client, 'get_client')
-    def test__invalidate_cached_client(self, mock_get_client):
-        mock_get_client.side_effect = get_new_fake_client
-        ironicclient = client_wrapper.IronicClientWrapper()
-        first_client = ironicclient._get_client()
-        ironicclient._invalidate_cached_client()
-        second_client = ironicclient._get_client()
-        self.assertNotEqual(id(first_client), id(second_client))
-
-    @mock.patch.object(ironic_client, 'get_client')
-    def test_call_uses_cached_client(self, mock_get_client):
-        mock_get_client.side_effect = get_new_fake_client
-        ironicclient = client_wrapper.IronicClientWrapper()
-        for n in range(0, 4):
-            ironicclient.call("node.list")
-        self.assertEqual(1, mock_get_client.call_count)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=0.6,!=0.7,<1.0
-Babel>=1.3
+Babel==1.3
 python-ironicclient==0.2.1
-python-novaclient==2.20.0
+python-novaclient==2.22.0


### PR DESCRIPTION
Now wrapped clients will derive from OpenstackClientWrapper, which
provides client caching, and call retrying.

Adapted NovaClientWrapper and IronicClientWrapper to use
OpenstackClientWrapper.

Updated tests to reflect the new reality.

Updated novaclient requirement to use 2.22.0.