### PR TITLE
Changes after testing against DevStack

### DIFF
--- a/arsenal/director/devstack_scout.py
+++ b/arsenal/director/devstack_scout.py
@@ -1,0 +1,63 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2015 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo.config import cfg
+
+from arsenal.director import onmetal_scout as onmetal
+from arsenal.openstack.common import log
+
+LOG = log.getLogger(__name__)
+
+CONF = cfg.CONF
+
+
+def is_baremetal_image(glance_image):
+    return glance_image.name == 'cirros-0.3.2-x86_64-disk'
+
+
+def is_baremetal_flavor(flavor):
+    return flavor.name == "baremetal"
+
+
+class DevstackScout(onmetal.OnMetalScout):
+    def retrieve_image_data(self):
+        """Get information about images to pass to a CachingStrategy object.
+
+        """
+        self.glance_data = filter(is_baremetal_image,
+                                  self.glance_client.call("images.list"))
+        return map(onmetal.convert_glance_image, self.glance_data)
+
+    def retrieve_flavor_data(self):
+        """Get information about flavors to pass to a CachingStrategy object.
+
+        """
+        flavor_list = filter(is_baremetal_flavor,
+                             self.nova_client.call("flavors.list"))
+        unknown_flavors = filter(lambda f: (onmetal.KNOWN_FLAVORS.get(f.id)
+                                            is None),
+                                 flavor_list)
+        for flavor in unknown_flavors:
+            onmetal.KNOWN_FLAVORS[flavor.id] = lambda node: (
+                node.properties['memory_mb'] == flavor.ram)
+            LOG.warning("Detected an unknown flavor of id "
+                        "%(flavor_id)s. Adding to known flavor list, and "
+                        "identifying by amount of memory reported, which is "
+                        "%(memory)s",
+                        {'flavor_id': flavor.id,
+                         'memory': flavor.ram})
+        return map(onmetal.convert_nova_flavor, flavor_list)

--- a/arsenal/director/onmetal_scout.py
+++ b/arsenal/director/onmetal_scout.py
@@ -36,7 +36,7 @@ def is_node_provisioned(ironic_node):
 
 def is_node_cached(ironic_node):
     cache_status = ironic_node.driver_info.get('cache_status')
-    if cache_status is None:
+    if cache_status is None or cache_status == 'failed':
         return False
     else:
         return True
@@ -123,12 +123,12 @@ class OnMetalScout(scout.Scout):
         for flavor in unknown_flavors:
             KNOWN_FLAVORS[flavor.id] = lambda node: (
                 node.properties['memory_mb'] == flavor.ram)
-            LOG.warning("OnMetalScout detected an unknown flavor of id "
+            LOG.warning("Detected an unknown flavor of id "
                         "%(flavor_id)s. Adding to known flavor list, and "
                         "identifying by amount of memory reported, which is "
                         "%(memory)s",
                         {'flavor_id': flavor.id,
-                         'memory': flavor.memory_mb})
+                         'memory': flavor.ram})
         return map(convert_nova_flavor, flavor_list)
 
     def retrieve_image_data(self):
@@ -151,7 +151,7 @@ class OnMetalScout(scout.Scout):
         elif isinstance(action, sb.EjectNode):
             return self.issue_eject_node(action)
 
-        LOG.error("OnMetalScout.issue_action: action is not a known "
+        LOG.error("Action is not a known "
                   "StrategyAction type! This method needs to be updated "
                   "in order to handle this action. Doing nothing for now.")
 
@@ -163,23 +163,26 @@ class OnMetalScout(scout.Scout):
         return None
 
     def issue_cache_node(self, cache_node_action):
+        LOG.debug("Issuing cache node operation on node %(node)s with "
+                  "image %(image)s", {'node': cache_node_action.node_uuid,
+                                      'image': cache_node_action.image_uuid})
         glance_image_data = self._find_glance_image(cache_node_action)
 
         if glance_image_data is None:
-            LOG.error("OnMetalScout.issue_cache_node: Could not find glance "
-                      "data for the image '%(image_id)s ! Doing nothing.",
+            LOG.error("Could not find glance data for the image "
+                      "'%(image_id)s'! Doing nothing.",
                       {'image_id': cache_node_action.node_uuid})
             return
 
         image_url = glance_image_data.get('file')
 
-        args = {
+        args = ({
             'image_info': {
                 'id': cache_node_action.image_uuid,
                 'urls': [CONF.glance.api_endpoint + image_url],
                 'checksum': cache_node_action.image_checksum
             }
-        }
+        })
 
         try:
             self.ironic_client.call('node.vendor_passthru',
@@ -191,6 +194,8 @@ class OnMetalScout(scout.Scout):
             LOG.exception(e)
 
     def issue_eject_node(self, eject_node_action):
+        LOG.debug("Issuing eject node command on node '%(node)s'.",
+                  {'node': eject_node_action.node_uuid})
         try:
             self.ironic_client.call('node.set_provision_state',
                                     node_uuid=eject_node_action.node_uuid,

--- a/arsenal/director/onmetal_scout.py
+++ b/arsenal/director/onmetal_scout.py
@@ -176,13 +176,13 @@ class OnMetalScout(scout.Scout):
 
         image_url = glance_image_data.get('file')
 
-        args = ({
+        args = {
             'image_info': {
                 'id': cache_node_action.image_uuid,
                 'urls': [CONF.glance.api_endpoint + image_url],
                 'checksum': cache_node_action.image_checksum
             }
-        })
+        }
 
         try:
             self.ironic_client.call('node.vendor_passthru',

--- a/arsenal/director/scheduler.py
+++ b/arsenal/director/scheduler.py
@@ -78,11 +78,6 @@ class DirectorScheduler(periodic_task.PeriodicTasks):
 
     @periodic_task.periodic_task(run_immediately=True,
                                  spacing=CONF.director.poll_spacing)
-    def poll_for_node_data(self, context):
-        self.node_data = self.scout.retrieve_node_data()
-
-    @periodic_task.periodic_task(run_immediately=True,
-                                 spacing=CONF.director.poll_spacing)
     def poll_for_flavor_data(self, context):
         self.flavor_data = self.scout.retrieve_flavor_data()
 
@@ -93,6 +88,10 @@ class DirectorScheduler(periodic_task.PeriodicTasks):
 
     @periodic_task.periodic_task(spacing=CONF.director.directive_spacing)
     def issue_directives(self, context):
+        # It's really important to have node state be as current as possible.
+        # So instead of polling for it, I'm leaving it tied to updating the
+        # state of the strategy.
+        self.node_data = self.scout.retrieve_node_data()
         self.strat.update_current_state(self.node_data, self.image_data,
                                         self.flavor_data)
         directives = self.strat.directives()

--- a/arsenal/external/client_wrapper.py
+++ b/arsenal/external/client_wrapper.py
@@ -131,10 +131,10 @@ class OpenstackClientWrapper(object):
             obj = getattr(obj, attribute)
         return obj
 
-    def call(self, method, *args, **kwargs):
+    def call(self, method_name, *args, **kwargs):
         """Call the specified client method and retry on errors.
 
-        :param method: Name of the client method to call as a string.
+        :param method_name: Name of the client method to call as a string.
         :param args: Client method arguments.
         :param kwargs: Client method keyword arguments.
 
@@ -149,7 +149,8 @@ class OpenstackClientWrapper(object):
             client = self._get_client()
 
             try:
-                return self._multi_getattr(client, method)(*args, **kwargs)
+                return self._multi_getattr(client, method_name)(*args,
+                                                                **kwargs)
             except auth_exceptions:
                 # In this case, the authorization token of the cached
                 # client probably expired. So invalidate the cached
@@ -167,7 +168,7 @@ class OpenstackClientWrapper(object):
             msg = ("Error contacting %(name)s server for "
                    "'%(method)s'. Attempt %(attempt)d of %(total)d" %
                    {'name': self.name,
-                    'method': method,
+                    'method': method_name,
                     'attempt': attempt,
                     'total': max_retries})
             if attempt == max_retries:

--- a/arsenal/tests/director/test_onmetal_scout.py
+++ b/arsenal/tests/director/test_onmetal_scout.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2015 Rackspace
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+test_onmetal_scout
+----------------------------------
+
+Tests for `onmetal_scout` module.
+"""
+
+import mock
+from oslo.config import cfg
+
+import arsenal.director.onmetal_scout as onmetal
+from arsenal.external import client_wrapper
+import arsenal.strategy.base as strat_base
+from arsenal.tests import base
+
+CONF = cfg.CONF
+
+
+TEST_GLANCE_IMAGE_DATA = [
+    {
+        'flavor_classes': 'onmetal',
+        'vm_mode': 'metal',
+        'visibility': 'public',
+        'name': 'ubuntu-14.04',
+        'id': 'aaaa',
+        'checksum': 'ubuntu-checksum',
+        'file': 'ubuntu_14_04_image.pxe'
+    },
+    {
+        'flavor_classes': 'onmetal',
+        'vm_mode': 'metal',
+        'visibility': 'public',
+        'name': 'ubuntu-14.10',
+        'id': 'bbbb',
+        'checksum': 'ubuntu-checksum',
+        'file': 'ubuntu_14_10_image.pxe'
+    },
+    {
+        'flavor_classes': 'onmetal',
+        'vm_mode': 'metal',
+        'visibility': 'public',
+        'name': 'coreos',
+        'id': 'cccc',
+        'checksum': 'coreos-checksum',
+        'file': 'coreos_image.pxe'
+    },
+    {
+        'flavor_classes': '!onmetal',
+        'vm_mode': 'metal',
+        'visibility': 'public',
+        'name': 'ubuntu-14.04_not_onmetal',
+        'id': 'dddd',
+        'checksum': 'ubuntu-not-onmetal-checksum',
+        'file': 'ubuntu_14_04_not_onmetal_image.pxe'
+    },
+    {
+        'flavor_classes': 'onmetal',
+        'vm_mode': 'not_onmetal',
+        'visibility': 'public',
+        'name': 'ubuntu-14.04_vm_mode_not_onmetal',
+        'id': 'eeee',
+        'checksum': 'ubuntu-vm_mode_not_onmetal_checksum',
+        'file': 'ubuntu_14_04_vm_mode_not_onmetal_image.pxe'
+    },
+    {
+        'flavor_classes': 'onmetal',
+        'vm_mode': 'metal',
+        'visibility': 'private',
+        'name': 'coreos_private',
+        'id': 'cccc',
+        'checksum': 'coreos-private-checksum',
+        'file': 'coreos_private.pxe'
+    },
+]
+
+GLANCE_IMAGE_DATA_BY_NAME = {
+    image['name']: image for image in TEST_GLANCE_IMAGE_DATA
+}
+
+
+class FakeFlavor(object):
+    def __init__(self, flavor_id, ram):
+        self.id = flavor_id
+        self.ram = ram
+
+
+TEST_NOVA_FLAVOR_DATA = [
+    FakeFlavor('onmetal-compute1', 32768),
+    FakeFlavor('onmetal-io1', 131072),
+    FakeFlavor('onmetal-memory1', 524288),
+    FakeFlavor('onmetal-gpu1', 65536),
+    FakeFlavor('some_other_flavor', 1024),
+    FakeFlavor('flavor_that_doesnt_start_with_onmetal', 2048),
+    FakeFlavor('onmetal_doesnt_match', 4096),
+]
+
+
+class TestOnMetalScout(base.TestCase):
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, 'call')
+    def setUp(self, wrapper_call_mock):
+        super(TestOnMetalScout, self).setUp()
+        CONF.set_override('api_endpoint', 'http://glance_endpoint', 'glance')
+        wrapper_call_mock.return_value = TEST_GLANCE_IMAGE_DATA
+        self.scout = onmetal.OnMetalScout()
+        self.scout.retrieve_image_data()
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, 'call')
+    def test_issue_cache_node_good_image(self, wrapper_call_mock):
+        cache_node_action = strat_base.CacheNode('node_uuid',
+                                                 'aaaa',
+                                                 'ubuntu-checksum')
+        expected_args = {
+            'image_info': {
+                'id': 'aaaa',
+                'urls': [CONF.glance.api_endpoint + 'ubuntu_14_04_image.pxe'],
+                'checksum': 'ubuntu-checksum'
+            }
+        }
+        self.scout.issue_cache_node(cache_node_action)
+        wrapper_call_mock.assert_called_once_with('node.vendor_passthru',
+                                                  node_id='node_uuid',
+                                                  method='cache_image',
+                                                  http_method='POST',
+                                                  args=expected_args)
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, 'call')
+    def test_issue_cache_node_bad_image(self, wrapper_call_mock):
+        cache_node_action = strat_base.CacheNode('node_uuid',
+                                                 'zzzz',
+                                                 'ubuntu-checksum')
+        self.scout.issue_cache_node(cache_node_action)
+        self.assertFalse(wrapper_call_mock.called,
+                         "The client should not have been called because "
+                         "a bad image uuid was passed!")
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, 'call')
+    def test_retrieve_flavor_data_only_returns_onmetal(self,
+                                                       wrapper_call_mock):
+        wrapper_call_mock.return_value = TEST_NOVA_FLAVOR_DATA
+        result = self.scout.retrieve_flavor_data()
+        expected_flavors = ('onmetal-compute1', 'onmetal-io1', 'onmetal-gpu1',
+                            'onmetal-memory1')
+
+        # NOTE(ClifHouck): This also implicitly tests retrieve_flavor_data's
+        # behavior to add unknown flavors to onmetal_scout.KNOWN_FLAVORS.
+        expected_result = [
+            strat_base.FlavorInput(f, onmetal.KNOWN_FLAVORS.get(f))
+            for f in expected_flavors
+        ]
+        self.assertItemsEqual([e.name for e in expected_result],
+                              [r.name for r in result],
+                              "retrieve_flavor_data did not properly filter "
+                              "for onmetal flavors!")
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, 'call')
+    def test_retrieve_image_data_only_returns_onmetal(self,
+                                                      wrapper_call_mock):
+        wrapper_call_mock.return_value = TEST_GLANCE_IMAGE_DATA
+        result = self.scout.retrieve_image_data()
+        expected_images = ('ubuntu-14.04', 'ubuntu-14.10', 'coreos')
+        expected_result = [
+            strat_base.ImageInput(i,
+                                  GLANCE_IMAGE_DATA_BY_NAME[i]['id'],
+                                  GLANCE_IMAGE_DATA_BY_NAME[i]['checksum'])
+            for i in expected_images
+        ]
+        self.assertItemsEqual([e.name for e in expected_result],
+                              [r.name for r in result],
+                              "retrieve_image_data did not properly filter "
+                              "for onmetal images!")

--- a/arsenal/tests/external/test_glance_client_wrapper.py
+++ b/arsenal/tests/external/test_glance_client_wrapper.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 from glanceclient.v2 import client as glance_client
+from keystoneclient.v2_0 import client as keystone_client
 import mock
 from oslo.config import cfg
 
@@ -33,9 +34,8 @@ class GlanceClientWrapperTestCase(test_base.TestCase):
         cfg.CONF.set_override('call_retry_interval', 0, 'client_wrapper')
 
     @mock.patch.object(glance_client, 'Client')
-    def test__get_client_no_auth_token(self, mock_ir_cli):
-        # FIXME: Sort pyrax situation out.
-        return
+    @mock.patch.object(keystone_client, 'Client')
+    def test__get_client_no_auth_token(self, mock_ks_cli, mock_glance_cli):
         self.flags(api_endpoint='glance-endpoint', group='glance')
         self.flags(admin_auth_token=None, group='glance')
         glanceclient = client_wrapper.GlanceClientWrapper()
@@ -43,21 +43,22 @@ class GlanceClientWrapperTestCase(test_base.TestCase):
         glanceclient.call("image.list")
         expected = {'username': CONF.glance.admin_username,
                     'password': CONF.glance.admin_password,
-                    'auth_url': CONF.glance.admin_url,
+                    'auth_url': CONF.glance.auth_endpoint,
                     'tenant_name': CONF.glance.admin_tenant_name,
                     'tenant_id': CONF.glance.admin_tenant_id,
-                    'region_name': CONF.glance.region_name}
+                    'region_name': CONF.glance.region_name,
+                    'insecure': True}
 
-        mock_ir_cli.assert_called_once_with(CONF.glance.api_endpoint,
-                                            **expected)
+        # Make sure we're getting a token from keystone.
+        mock_ks_cli.assert_called_once_with(**expected)
 
     @mock.patch.object(glance_client, 'Client')
-    def test__get_client_with_auth_token(self, mock_ir_cli):
+    def test__get_client_with_auth_token(self, mock_glance_cli):
         self.flags(api_endpoint='glance-endpoint', group='glance')
         self.flags(admin_auth_token='fake-token', group='glance')
         glanceclient = client_wrapper.GlanceClientWrapper()
         # dummy call to have _get_client() called
         glanceclient.call("image.list")
         expected = {'token': 'fake-token'}
-        mock_ir_cli.assert_called_once_with(CONF.glance.api_endpoint,
-                                            **expected)
+        mock_glance_cli.assert_called_once_with(CONF.glance.api_endpoint,
+                                                **expected)

--- a/etc/arsenal/arsenal.conf
+++ b/etc/arsenal/arsenal.conf
@@ -1,0 +1,86 @@
+# Example configuration file for Arsenal, the image caching service.
+
+# See arsenal/director/scheduler.py for director specific configuration 
+# options.
+[director]
+# Scout object to load and use in the director. (string value)
+# Available scouts can be found in arsenal/director/
+# scout=devstack_scout.DevstackScout
+
+# Enable or disable dry_run in the director. If True, no directives generated
+# by the strategy will be issued. (boolean value)
+# dry_run=False
+
+# Control the poll spacing for flavor and image data in seconds. 
+# (integer value)
+# poll_spacing=120
+
+# Control the spacing, in seconds, for issuing directives returned by the 
+# configured strategy. (integer value)
+# directive_spacing=15
+
+# Client wrapper config values are inherited where appropriate by all
+# openstack clients. See arsenal/external/client_wrapper.py for client 
+# wrapper specific configuration options.
+[client_wrapper]
+
+# Number of times to retry a client call. (integer value)
+# call_max_retries=3
+
+# Spacing, in seconds, between client call retries. (integer value)
+# call_retry_interval=3
+
+# The OpenStack tenant name. (string value)
+# os_tenant_name=demo
+
+# The OpenStack tenant id. (string value)
+# os_tenant_id=demo
+
+# The OpenStack username. (string value)
+# os_username=demo
+
+# The OpenStack region name. (string value)
+# region_name=RegionOne
+
+# The OpenStack service name. (string value)
+# service_name=ServiceName
+
+# The the auth system type to use. (string value)
+# auth_system=keystone
+
+# The OpenStack API url. (string value)
+# os_api_url=http://hostname.com:port/v2.0/
+
+# The OpenStack password. (string value)
+# os_password=password
+
+# See arsenal/external/nova_client_wrapper.py for nova client wrapper 
+# specific configuration options.
+[nova]
+ 
+# See arsenal/external/ironic_client_wrapper.py for ironic client wrapper 
+# specific configuration options.
+[ironic]
+# The username to use for Ironic. (string value)
+# admin_username=admin
+
+# The password to use for Ironic. (string value)
+# admin_password=password
+
+# The tenant name to use for Ironic. (string value)
+# admin_tenant_name=admin
+
+# Openstack's/Keystone API url. (string value)
+# admin_url=http://hostname.com:port/v2.0/
+
+# Ironic's API endpoint. (if different from OS) (string value)
+# api_endpoint=http://hostname.com:port
+
+# See arsenal/external/glance_client_wrapper.py for glance client wrapper 
+# specific configuration options.
+[glance]
+# Glance's API endpoint. (if different from OS) (string value)
+# api_endpoint=http://hostname.com:port
+
+# Auth token to use for Glance. (string value)
+# admin_auth_token=token_here

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Babel==1.3
 python-ironicclient==0.2.1
 python-novaclient==2.22.0
 python-glanceclient==0.16.1
-pyrax==1.9.3
+python-keystoneclient==1.3.0


### PR DESCRIPTION
Apologies again for a somewhat unfocused commit.

* Added a DevStack scout which should work for testing Aresnal in
        DevStack using the example agent driver Ironic DevStack configuration.
* A few small tweaks to OnMetalScout which solves issues found in
         testing.
* Small change to the DirectorScheduler to tie updating Ironic node
        state to generating strategy directives.
* Made the SimpleProportionalStrategy percentage a configuration option
        instead of a class argument.
* Change SimpleProportionalStrategy behavior to not try to
        cache 'fractional' nodes in order to meet or exceed the
        percentage directive. This avoids behavior where Arsenal will
        always cache the last unprovisioned node in order to meet its
        caching goal, in exchange for not always strictly meeting the
        caching goal.
* Updated SimpleProportionalStrategy tests to match behavior.
* Added an example arsenal configuration file.