### PR TITLE
Fix eject node behavior in OnMetalScout

### DIFF
--- a/arsenal/director/onmetal_scout.py
+++ b/arsenal/director/onmetal_scout.py
@@ -221,8 +221,15 @@ class OnMetalScout(scout.Scout):
         LOG.info("Issuing eject node command on node '%(node)s'.",
                  {'node': eject_node_action.node_uuid})
         try:
+            LOG.debug("Sending %(node)s to 'managed' state.",
+                      {'node': eject_node_action.node_uuid})
             self.ironic_client.call('node.set_provision_state',
                                     node_uuid=eject_node_action.node_uuid,
-                                    state='DELETED')
+                                    state='MANAGE')
+            LOG.debug("Sending %(node)s to 'provide' state.",
+                      {'node': eject_node_action.node_uuid})
+            self.ironic_client.call('node.set_provision_state',
+                                    node_uuid=eject_node_action.node_uuid,
+                                    state='PROVIDE')
         except exc.ArsenalException as e:
             LOG.exception(e)

--- a/arsenal/tests/director/test_onmetal_scout.py
+++ b/arsenal/tests/director/test_onmetal_scout.py
@@ -207,3 +207,16 @@ class TestOnMetalScout(base.TestCase):
                               [r.name for r in result],
                               "retrieve_image_data did not properly filter "
                               "for onmetal images!")
+
+    @mock.patch.object(client_wrapper.OpenstackClientWrapper, 'call')
+    def test_issue_eject_node_calls_manage_and_provide(self,
+                                                       wrapper_call_mock):
+        eject_node_action = strat_base.EjectNode('node_uuid')
+        self.scout.issue_eject_node(eject_node_action)
+        calls = [
+            mock.call('node.set_provision_state', node_uuid='node_uuid',
+                      state='MANAGE'),
+            mock.call('node.set_provision_state', node_uuid='node_uuid',
+                      state='PROVIDE')
+        ]
+        wrapper_call_mock.assert_has_calls(calls)


### PR DESCRIPTION
Instead of setting an available node to 'deleted', we now first
send the node to 'manage', and then 'provide' which will send the node
through cleaning, thus removing the cached image and reseting the state
of the machine to before it was cached.

Fixes #41