### PR TITLE
changing the region to prod/mimic on the config

### DIFF
--- a/arsenal/tests/functional/base.py
+++ b/arsenal/tests/functional/base.py
@@ -191,7 +191,7 @@ class TestCase(base.BaseTestCase):
                  'call_retry_interval': 3,
                  'os_tenant_name': 232323,
                  'os_username': 'test-user',
-                 'region_name': 'ORD',
+                 'region_name': 'IAD',
                  'service_name': 'cloudServersOpenStack',
                  'auth_system': 'rackspace',
                  'os_api_url': '{0}:{1}/identity/v2.0'.format(


### PR DESCRIPTION
The latest version on Mimic lists OnMetal images only for IAD region.