### PR TITLE
Fix AttributeError and wrong keyword in segregate_nodes

### DIFF
--- a/arsenal/strategy/simple_proportional_strategy.py
+++ b/arsenal/strategy/simple_proportional_strategy.py
@@ -70,8 +70,9 @@ def segregate_nodes(nodes, flavors):
     for node in nodes:
         if node.flavor not in flavor_names:
             LOG.error("Node '%(node)s'with unrecognized flavor '%(flavor)s "
-                      "detected. ", {'node': node.uuid, 'flavor': node.flavor})
-            next
+                      "detected. ", {'node': node.node_uuid,
+                                     'flavor': node.flavor})
+            continue
         nodes_by_flavor[node.flavor].append(node)
 
     return nodes_by_flavor


### PR DESCRIPTION
The AttributeError and keyword error are both exposed when a node is
fed to segregate_nodes which does not exist in 'flavors'.

Along with unit tests which expose and cover these problems.