### PR TITLE
Bump python-novaclient pin to 2.27.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ oslo.service==0.3.0
 oslo.config==1.14.0
 
 python-ironicclient==0.7.0
-python-novaclient==2.26.0
+python-novaclient==2.27.0
 python-glanceclient==0.19.0
 python-keystoneclient==1.6.0


### PR DESCRIPTION
Addresses an incompatability with pyrax :<